### PR TITLE
Add rater and commander comments for Enlisted EPRs

### DIFF
--- a/js/import-bullets.js
+++ b/js/import-bullets.js
@@ -10,11 +10,11 @@ const Forms  = {
             'likelyWidth':'202.321mm'
         },
         'AF910': {
-            'fields': ['KeyDuties','IIIComments','IVComments','VComments'],
+            'fields': ['KeyDuties','IIIComments','IVComments','VComments', 'VIIIComments', 'IXComments'],
             'likelyWidth':'202.321mm'
         },
         'AF911': {
-            'fields': ['KeyDuties','IIIComments','IVComments'],
+            'fields': ['KeyDuties','IIIComments','IVComments', 'VIIComments', 'VIIIComments', 'IXComments'],
             'likelyWidth':'202.321mm'
         },
     }


### PR DESCRIPTION
This bug was due to my own lack of awareness of how Enlisted EPRs work. 

During my initial testing of importing bullets from Enlisted EPRs, I noticed that the Additional Rater and Commander's comments fields were disabled. Because they were disabled, I assumed they were rarely used and ignored them from the test cases. 

Turns out that these fields ONLY become enabled once all preceding text areas have been filled out with information! So I made some updated test PDFs with all information filled out for AF910/AF911, and was able to correctly test to see if this works. 

On the coding implementation side, it was rather straightforward, just updating the array of fields to check.